### PR TITLE
fix: set correct font for buttons

### DIFF
--- a/tiny-brutalism.css
+++ b/tiny-brutalism.css
@@ -73,6 +73,7 @@ button, .button {
     box-shadow: 4px 4px 0 #000;
     cursor: pointer;
     transition: all 0.2s ease;
+    font-family: 'Roboto Mono', monospace;
 }
 
 button:hover, .button:hover {


### PR DESCRIPTION
Was working on integrating your lovely CSS into a personal website, and noticed that the font for the button text is not correct and was defaulting to the browser default and not `Roboto Mono`.